### PR TITLE
fix package name issue ahead of composer v2.0 release

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name": "bea/composer/scaffold-plugin",
+	"name": "beapi/composer-scaffold-plugin",
 	"type": "composer-plugin",
 	"license": "MIT",
 	"authors": [


### PR DESCRIPTION
**This is a BC**

This pull request fixes issue #4.

It will apply the following changes :

*  Fix invalid package name for Composer v2

This should be tag with a major version when released.
