### PR TITLE
Fix hardcoded install path

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
 	],
 	"require": {
 		"php": ">=5.6",
-		"composer-plugin-api": "^1.1"
+		"composer-plugin-api": "^1.1",
+		"composer/installers": "^1.5"
 	},
 	"require-dev": {
 		"composer/composer": "^1.6"


### PR DESCRIPTION
<!--
Thanks for contributing !

Please note :
- These comments won't show up when you submit the pull request.
- Please provide tests, if you can.
-->

Until now the installation path for scaffolded plugins was hardcoded. This pull request implement a new method to detect the correct installation path.

It will apply the following changes :

* Improve the way we detect WordPress plugins folder path
* Add a new dependency `composer/installers`
